### PR TITLE
No empty assets when merging

### DIFF
--- a/classes/assets.php
+++ b/classes/assets.php
@@ -138,6 +138,9 @@ class Assets {
 		// Go through each asset group
 		foreach ($this->groups as $type => $group)
 		{
+			if ( ! $group->count())
+				continue;
+			
 			if ($this->merge())
 			{
 				// Add merged file to html


### PR DESCRIPTION
Fix for issue #8

When rendering the asset groups if a group does not have any assets, it will not be rendered.

This could happen if for example  you have both css and js paths in your configuration, but a certain group consists of only one type of assets.

This change does not change the asset merger behavior when the assets are not merged.
