### PR TITLE
Using empty folder can lead to broken URLs. 

### DIFF
--- a/classes/kohana/assets.php
+++ b/classes/kohana/assets.php
@@ -60,7 +60,7 @@ abstract class Kohana_Assets {
 		// Set file
 		$file = substr($file, 0, strrpos($file, $type)).$type;
 
-		return Kohana::$config->load('asset-merger.folder').'/'.$type.'/'.$file;
+		return ltrim(Kohana::$config->load('asset-merger.folder').'/'.$type.'/'.$file, '/');
 	}
 
 	// Default short names for types


### PR DESCRIPTION
If an empty asset-merger.folder is specified (we put the rendered script and style directories into the root directory), Kohana_Assets::web_path returns a path with a leading slash.

This path is passed to Html::script and Html::style, which combines it with the path in Url::base (which returns a trailing slash), which results in doubles slashes in the URL. In some cases this has caused an issue.

I've used ltrim to remote the leading slash. 
