### PR TITLE
Call to undefined method Asset_Block::type()

### DIFF
--- a/classes/kohana/asset/block.php
+++ b/classes/kohana/asset/block.php
@@ -7,7 +7,7 @@
 * @copyright  (c) 2011-2012 Despark Ltd.
 * @license    http://creativecommons.org/licenses/by-sa/3.0/legalcode
 */
-abstract class Kohana_Asset_Block extends Asset {
+abstract class Kohana_Asset_Block extends Kohana_Asset {
 
 	/**
 	 * @var  string  content


### PR DESCRIPTION
public function type() is in Kohana_Asset but block.php is extending Asset thus doesn't have access to $this->type()
