### PR TITLE
#31 - resource integrity check

### DIFF
--- a/classes/Kohana/Asset.php
+++ b/classes/Kohana/Asset.php
@@ -41,7 +41,7 @@ abstract class Kohana_Asset {
 	 * @param   integer  $cache_buster
 	 * @return  string
 	 */
-	public static function html($type, $file, $cache_buster = NULL, $async = FALSE)
+	public static function html($type, $file, $cache_buster = NULL, $async = FALSE, $integrity = NULL)
 	{
 		if ($cache_buster)
 		{
@@ -53,10 +53,10 @@ abstract class Kohana_Asset {
 		switch ($type)
 		{
 			case Assets::JAVASCRIPT:
-				return '<script type="text/javascript" src="'.$file.'"'.($async ? ' async="async"' : '').'></script>';
+				return '<script type="text/javascript" src="'.$file.'"'.($async ? ' async="async"' : '').(!is_null($integrity) ? ' integrity="'.$integrity.'" crossorigin="anonymous"' : '').'></script>';
 			
 			case Assets::STYLESHEET:
-				return '<link type="text/css" href="'.$file.'" rel="stylesheet" />';
+				return '<link type="text/css" href="'.$file.'"'.(!is_null($integrity) ? ' integrity="'.$integrity.'" crossorigin="anonymous"' : '').' rel="stylesheet" />';
 		}
 	}
 

--- a/config/asset-merger.php
+++ b/config/asset-merger.php
@@ -7,6 +7,8 @@ return array(
 		Assets::JAVASCRIPT => DOCROOT.'js'.DIRECTORY_SEPARATOR,
 		Assets::STYLESHEET => DOCROOT.'css'.DIRECTORY_SEPARATOR,
 	),
+	//To enable set this as sha256, sha384 or sha512 with merging enabled
+	'integrity_check' => FALSE,
 	'processor'  => array(
 		Assets::STYLESHEET => 'cssmin',
 	),


### PR DESCRIPTION
As mentioned in the task I added a integrity check which can be one of sha256, sha384 or sha512. This integrity value is generated using

`base64_encode(hash_file($this->_hash, $file, TRUE))`

I enabled this feature only for merged files, as I believe this can slow down a site if done on every asset.