### PR TITLE
#34 Paths based on URL::site for projects not in main web folder

### DIFF
--- a/classes/Kohana/Asset/Collection.php
+++ b/classes/Kohana/Asset/Collection.php
@@ -203,7 +203,7 @@ abstract class Kohana_Asset_Collection implements Iterator, Countable, ArrayAcce
 		}
 		else
 		{
-			$file = DOCROOT . $this->destination_web();
+			$file = str_replace(Kohana::$base_url, '', DOCROOT . $this->destination_web());
 		}
 		
 		if ($this->_integrity)

--- a/classes/Kohana/Assets.php
+++ b/classes/Kohana/Assets.php
@@ -60,7 +60,7 @@ abstract class Kohana_Assets {
 		// Set file
 		$file = substr($file, 0, strrpos($file, $type)).$type;
 
-		return '/'.Kohana::$config->load('asset-merger.folder').'/'.$type.'/'.$file;
+		return URL::site(Kohana::$config->load('asset-merger.folder').'/'.$type.'/'.$file);
 	}
 
 	// Default short names for types


### PR DESCRIPTION
Fixes issue, when Kohana is placed in a folder, for example "/kohana/" and asset-merger paths do not reflect that path.